### PR TITLE
Make it clear which thread in a live report is generating the report

### DIFF
--- a/Sources/AardvarkCrashReport/CrashReportAttachmentGenerator.swift
+++ b/Sources/AardvarkCrashReport/CrashReportAttachmentGenerator.swift
@@ -53,12 +53,14 @@ public final class CrashReportAttachmentGenerator {
 
     /// Generates a bug report attachment containing a textual representation of a live crash report.
     ///
+    /// The report will be generated on the thread on which this method is called.
+    ///
     /// - parameter crashReporter: The crash reporter to use to generate the live report.
     public static func attachmentForLiveReport(
         from crashReporter: PLCrashReporter
     ) -> ARKBugReportAttachment? {
         do {
-            let data = try crashReporter.generateLiveReportAndReturnError()
+            let data = try THIS_THREAD_IS_GENERATING_A_CRASH_REPORT(crashReporter)
             let crashReport = try PLCrashReport(data: data)
             return attachment(for: crashReport)
 
@@ -99,4 +101,10 @@ public final class CrashReportAttachmentGenerator {
         )
     }
 
+}
+
+// MARK: -
+
+private func THIS_THREAD_IS_GENERATING_A_CRASH_REPORT(_ crashReporter: PLCrashReporter) throws -> Data {
+    return try crashReporter.generateLiveReportAndReturnError()
 }


### PR DESCRIPTION
<img width="666" alt="Screen Shot 2021-03-15 at 8 35 28 PM" src="https://user-images.githubusercontent.com/1857549/111252274-fcbd8200-85cd-11eb-8625-092fa4da71f3.png">
