### PR TITLE
Remove EXCLUDED_ARCHS setting

### DIFF
--- a/AardvarkCrashReport.podspec
+++ b/AardvarkCrashReport.podspec
@@ -16,7 +16,4 @@ Pod::Spec.new do |s|
 
   s.dependency 'Aardvark', '~> 4.0'
   s.dependency 'PLCrashReporter', '~> 1.8'
-
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
This was originally added to work around, we presume, an Xcode 12.0 build
issue. This doesn't appear to be necessary anymore, and keeping it around
prevents apps that depend on AardvarkCrashReport from building successfully
on Apple Silicon.