### PR TITLE
Add explicit global source to Gemfile

### DIFF
--- a/Example/Gemfile
+++ b/Example/Gemfile
@@ -1,3 +1,3 @@
-source 'https://rubygems.org' do
-  gem 'cocoapods', '1.10.0'
-end
+source 'https://rubygems.org'
+
+gem 'cocoapods', '1.10.0'

--- a/Example/Gemfile.lock
+++ b/Example/Gemfile.lock
@@ -87,7 +87,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (= 1.10.0)!
+  cocoapods (= 1.10.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.31


### PR DESCRIPTION
Bundler now requires an explicit global source in the Gemfile, and will
log a deprecation warning if this isn't specified. This change adds
rubygems.org as a global source to satisfy the new requirements.