### PR TITLE
Update PLCrashReporter from 1.8.x to 1.10.x

### DIFF
--- a/AardvarkCrashReport.podspec
+++ b/AardvarkCrashReport.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/AardvarkCrashReport/**/*.{h,m,swift}'
 
   s.dependency 'Aardvark', '~> 4.0'
-  s.dependency 'PLCrashReporter', '~> 1.8'
+  s.dependency 'PLCrashReporter', '~> 1.10'
 end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -3,14 +3,14 @@ PODS:
     - CoreAardvark (~> 3.0)
   - AardvarkCrashReport (2.0.0):
     - Aardvark (~> 4.0)
-    - PLCrashReporter (~> 1.8)
+    - PLCrashReporter (~> 1.10)
   - AardvarkLoggingUI (1.0.0):
     - CoreAardvark (~> 3.0)
   - AardvarkMailUI (1.0.0):
     - Aardvark (~> 4.0)
   - CoreAardvark (3.0.0)
   - Paralayout (0.9.1)
-  - PLCrashReporter (1.8.1)
+  - PLCrashReporter (1.10.1)
 
 DEPENDENCIES:
   - AardvarkCrashReport (from `../AardvarkCrashReport.podspec`)
@@ -41,12 +41,12 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Aardvark: 6d84a2e9d317d3b5ff7bf9b860c6e2ccf444043c
-  AardvarkCrashReport: 6482368b1777f98a2b9c817f2def7dd19786c679
+  AardvarkCrashReport: 72b0eaf0978a54877f5eaccbbd386183000b5864
   AardvarkLoggingUI: e81aae53c747dcc7c7e757d87b989316c1699261
   AardvarkMailUI: a3b61ff1fbd62c9d33703efc3f0cc34597afad73
   CoreAardvark: 9c943d82736bc261ff4130287aa25e4f35dc7567
   Paralayout: 3e82899bd0d18ad2db21212cd453efa291d2c0cf
-  PLCrashReporter: ea2d252e930f538a9f70f0b81bc9cce656651fbf
+  PLCrashReporter: b30195e509f07299ea277d1997b3a39449d05698
 
 PODFILE CHECKSUM: 1511f97db86d7bfef3721e89da4b9bff28ae494c
 


### PR DESCRIPTION
1.10.x is published as an xcframework, which is necessary for
PLCrashReporter - and by extension AardvarkCrashReport - to support
Apple Silicon.