### PR TITLE
Bump version from 2.0.0 to 3.0.0

### DIFF
--- a/AardvarkCrashReport.podspec
+++ b/AardvarkCrashReport.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AardvarkCrashReport'
-  s.version          = '2.0.0'
+  s.version          = '3.0.0'
   s.summary          = 'AardvarkCrashReport makes it easy to provide high quality data about crashes in your bug reports.'
   s.homepage         = 'https://github.com/cashapp/AardvarkCrashReport'
   s.license          = { :type => 'Apache 2.0', :file => 'LICENSE' }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Aardvark (4.0.0):
     - CoreAardvark (~> 3.0)
-  - AardvarkCrashReport (2.0.0):
+  - AardvarkCrashReport (3.0.0):
     - Aardvark (~> 4.0)
     - PLCrashReporter (~> 1.10)
   - AardvarkLoggingUI (1.0.0):
@@ -41,7 +41,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   Aardvark: 6d84a2e9d317d3b5ff7bf9b860c6e2ccf444043c
-  AardvarkCrashReport: 72b0eaf0978a54877f5eaccbbd386183000b5864
+  AardvarkCrashReport: 4d11fae6db029943a03c2a94db4eae6be6663b4c
   AardvarkLoggingUI: e81aae53c747dcc7c7e757d87b989316c1699261
   AardvarkMailUI: a3b61ff1fbd62c9d33703efc3f0cc34597afad73
   CoreAardvark: 9c943d82736bc261ff4130287aa25e4f35dc7567


### PR DESCRIPTION
Since changing the binary format of PLCrashReporter to an xcframework
could be a breaking change for consumers, we are bumping the major
version for this next release.